### PR TITLE
docs: Fix a few typos

### DIFF
--- a/scripts/controllers.py
+++ b/scripts/controllers.py
@@ -15,7 +15,7 @@ class Controller():
 		self.g = 9.81				# acceleration of gravity [m/s^2]
 		self.Ix = 6.228e-3			# longitudinal inertia [kgm^2]
 		self.Iy = 6.228e-3			# lateral inertia [kgm^2]
-		self.Iz = 1.121e-3			# vertial inertia [kgm^2]
+		self.Iz = 1.121e-3			# vertical inertia [kgm^2]
 
 		# actuator values
 		self.u  = np.array([0.0, 0.0, 0.0, 0.0])		# actual

--- a/scripts/gui.py
+++ b/scripts/gui.py
@@ -333,7 +333,7 @@ class Baldr():
 		if self.get_gui_state() and not self.simulation_isrunning:
 			# if a simulator and an integrator have been selected
 			if self.params['simulator']['value'] and self.params['integrator']['value']:
-				# if bspline is the selcted trajectory, then a file must be loaded
+				# if bspline is the selected trajectory, then a file must be loaded
 				if self.params['trajectory']['value'] == 'custom' and self.open_filename:
 					self.enable(self.initialize_button)
 				elif self.params['trajectory']['value'] != 'custom':

--- a/scripts/models.py
+++ b/scripts/models.py
@@ -13,7 +13,7 @@ class Model():
 		self.g 		= 9.81					# acceleration of gravity [m/s^2]
 		self.Ix 	= 6.228e-3				# longitudinal inertia [kgm^2]
 		self.Iy 	= 6.228e-3				# lateral inertia [kgm^2]
-		self.Iz		= 1.121e-3				# vertial inertia [kgm^2]
+		self.Iz		= 1.121e-3				# vertical inertia [kgm^2]
 		self.Jr  	= 6e-5					# rotor inertia [kgm^2]
 		self.l   	= 0.232					# blade length [m]
 		self.rho 	= 1.293					# air density [kgm^-3]

--- a/scripts/snap.py
+++ b/scripts/snap.py
@@ -174,7 +174,7 @@ class Trajectory1D:
 			 [ ...            ... ]]
 		Omitted derivatives will be left free, and any 
 		derivatives up to and including the objective 
-		(der) derivative will be made continous on the 
+		(der) derivative will be made continuous on the 
 		waypoints.
 		'''
 
@@ -238,7 +238,7 @@ class Trajectory1D:
 			# input values: specified waypoint derivatives
 			d[0].extend(self.wp[i])
 
-			# None: unspecificed waypoint derivatives
+			# None: unspecified waypoint derivatives
 			if len(self.wp[i]) < (self.match + 1):
 				d[0].extend([None] * ((self.match + 1) - len(self.wp[i])))
 


### PR DESCRIPTION
There are small typos in:
- scripts/controllers.py
- scripts/gui.py
- scripts/models.py
- scripts/snap.py

Fixes:
- Should read `vertical` rather than `vertial`.
- Should read `unspecified` rather than `unspecificed`.
- Should read `selected` rather than `selcted`.
- Should read `continuous` rather than `continous`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md